### PR TITLE
Quick fix to show deltas on square watches.

### DIFF
--- a/wear/src/main/res/layout/rect_activity_home.xml
+++ b/wear/src/main/res/layout/rect_activity_home.xml
@@ -71,8 +71,7 @@
                     android:textColor="#FFFFFF"
                     android:layout_gravity="bottom"
                     android:gravity="center_horizontal|bottom"
-                    android:textStyle="bold"
-                    android:singleLine="true" />
+                    android:textStyle="bold" />
 
 
             </LinearLayout>


### PR DESCRIPTION
... please see it just as a hint where to look, It's almost midnight and I've been up since 6 in the morning.
It seems to have fixed the issue https://github.com/StephenBlackWasAlreadyTaken/NightWatch/issues/30 on my LG G Watch (rectangular Watch).