### PR TITLE
launch Home activity in singleInstance mode

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         <meta-data android:name="AA_DB_NAME" android:value="NightWatch.db" />
         <meta-data android:name="AA_DB_VERSION" android:value="4" />
 
-        <activity android:name=".Activities.Home" android:label="@string/app_name" >
+        <activity android:name=".Activities.Home" android:label="@string/app_name" android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Multiple instances could have happend if user doesn't com back from BG Level Alerts/Statistics/... with the back key but via the NavDrawer.